### PR TITLE
Cart::getProducts refactoring

### DIFF
--- a/protected/common/modules/cart/models/Cart.php
+++ b/protected/common/modules/cart/models/Cart.php
@@ -174,7 +174,7 @@ class Cart extends \yii\base\Model
      */
     public function getProducts()
     {
-        return iterator_to_array($this->itemsList);
+        return iterator_to_array($this->itemsList, false);
     }
     
     /**

--- a/protected/common/modules/cart/models/Cart.php
+++ b/protected/common/modules/cart/models/Cart.php
@@ -174,15 +174,7 @@ class Cart extends \yii\base\Model
      */
     public function getProducts()
     {
-        $products   = [];
-        if(!empty($this->itemsList))
-        {
-            foreach($this->itemsList as $productId => $cartData)
-            {
-                $products[] = $cartData;
-            }
-        }
-        return $products;
+        return iterator_to_array($this->itemsList);
     }
     
     /**


### PR DESCRIPTION
1. $this->itemsList can not be empty, because you initialize it in constructor
2. It's most simple way to get traversable object items